### PR TITLE
RuneScapeSection inconsistents configID

### DIFF
--- a/src/sections/RuneScapeGuideSection.java
+++ b/src/sections/RuneScapeGuideSection.java
@@ -109,7 +109,7 @@ public final class RuneScapeGuideSection extends TutorialSection {
                     }
                 }
             default:
-                Sleep.sleepUntil(() -> getConfigs().get(1042) != configValue, 1200);
+                Sleep.sleepUntil(() -> getConfigs().get(configID) != configValue, 1200);
         }
     }
 


### PR DESCRIPTION
Changed the Value 1042 with the configID
Preventing future errors

Nothing big, but why not 🤷‍♂️ 